### PR TITLE
Instead of fast failing, nerve should auto-remediate

### DIFF
--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -83,7 +83,6 @@ module Nerve
       raise e
     ensure
       log.info "nerve: ending service watch #{@name}"
-      $EXIT = true
       @reporter.stop
     end
 

--- a/lib/nerve/service_watcher/http.rb
+++ b/lib/nerve/service_watcher/http.rb
@@ -40,7 +40,7 @@ module Nerve
           log.debug "nerve: check #{@name} got response code #{code} with body \"#{body}\""
           return true
         else
-          log.error "nerve: check #{@name} got response code #{code} with body \"#{body}\""
+          log.warn "nerve: check #{@name} got response code #{code} with body \"#{body}\""
           return false
         end
       end


### PR DESCRIPTION
Zookeeper is a CP store, not an AP store, so it flakes sometimes. In
production this means that we will often see networking flakes in one
datacenter impact another's registrations, and that's not ok. This patch
makes it so that instead of failing fast, nerve continuously tries to
revive dead watchers.
