### PR TITLE
Support an 'extra' key that gets serialized into etcd/zk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The configuration contains the following options:
 * `reporter_type`: the mechanism used to report up/down information; depending on the reporter you choose, additional parameters may be required. Defaults to `zookeeper`
 * `check_interval`: the frequency with which service checks will be initiated; defaults to `500ms`
 * `checks`: a list of checks that nerve will perform; if all of the pass, the service will be registered; otherwise, it will be un-registered
+* `weight`: a positive integer weight value which can be used to affect the haproxy backend weighting in synapse.
 
 #### Zookeeper Reporter ####
 

--- a/example/nerve_services/etcd_service1.json
+++ b/example/nerve_services/etcd_service1.json
@@ -6,6 +6,7 @@
   "etcd_port": 4001,
   "etcd_path": "/nerve/services/your_http_service/services",
   "check_interval": 2,
+  "weight": 2,
   "checks": [
     {
       "type": "http",

--- a/example/nerve_services/zookeeper_service1.json
+++ b/example/nerve_services/zookeeper_service1.json
@@ -5,6 +5,7 @@
   "zk_hosts": ["localhost:2181"],
   "zk_path": "/nerve/services/your_http_service/services",
   "check_interval": 2,
+  "weight": 2,
   "checks": [
     {
       "type": "http",

--- a/lib/nerve/reporter/base.rb
+++ b/lib/nerve/reporter/base.rb
@@ -25,6 +25,17 @@ class Nerve::Reporter
     def ping?
     end
 
+    def get_service_data(service)
+      %w{instance_id host port}.each do |required|
+        raise ArgumentError, "missing required argument #{required} for new service watcher" unless service[required]
+      end
+      d = {'host' => service['host'], 'port' => service['port'], 'name' => service['instance_id']}
+      if service['weight'].to_i >= 0 and "#{service['weight']}".match /^\d+$/
+        d['weight'] = service['weight'].to_i
+      end
+      d
+    end
+
     protected
     def parse_data(data)
       return data if data.class == String

--- a/lib/nerve/reporter/etcd.rb
+++ b/lib/nerve/reporter/etcd.rb
@@ -4,14 +4,12 @@ require 'etcd'
 class Nerve::Reporter
   class Etcd < Base
     def initialize(service)
-      %w{etcd_host instance_id host port}.each do |required|
-        raise ArgumentError, "missing required argument #{required} for new service watcher" unless service[required]
-      end
+      raise ArgumentError, "missing required argument etcd_host for new service watcher" unless service['etcd_host']
       @host = service['etcd_host']
       @port = service['etcd_port'] || 4003
       path = service['etcd_path'] || '/'
       @path = path.split('/').push(service['instance_id']).join('/')
-      @data = parse_data({'host' => service['host'], 'port' => service['port'], 'name' => service['instance_id']})
+      @data = parse_data(get_service_data(service))
       @key = nil
       @ttl = (service['check_interval'] || 0.5) * 5
       @ttl = @ttl.ceil

--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -10,12 +10,12 @@ class Nerve::Reporter
     @@zk_pool_lock = Mutex.new
 
     def initialize(service)
-      %w{zk_hosts zk_path instance_id host port}.each do |required|
+      %w{zk_hosts zk_path}.each do |required|
         raise ArgumentError, "missing required argument #{required} for new service watcher" unless service[required]
       end
       # Since we pool we get one connection per zookeeper cluster
       @path = service['zk_hosts'].sort.join(',')
-      @data = parse_data({'host' => service['host'], 'port' => service['port'], 'name' => service['instance_id']})
+      @data = parse_data(get_service_data(service))
 
       @zk_path = service['zk_path']
       @key = @zk_path + "/#{service['instance_id']}_"

--- a/spec/example_services_spec.rb
+++ b/spec/example_services_spec.rb
@@ -1,6 +1,11 @@
 require 'json'
 require 'nerve/reporter'
+require 'nerve/reporter/base'
 require 'nerve/service_watcher'
+
+class Nerve::Reporter::Base
+  attr_reader :data
+end
 
 describe "example services are valid" do
   Dir.foreach("#{File.dirname(__FILE__)}/../example/nerve_services") do |item|
@@ -14,6 +19,9 @@ describe "example services are valid" do
         reporter = nil
         expect { reporter = Nerve::Reporter.new_from_service(service_data) }.to_not raise_error()
         expect(reporter.is_a?(Nerve::Reporter::Base)).to eql(true)
+      end
+      it 'saves the weight data' do
+        expect(JSON.parse(Nerve::Reporter.new_from_service(service_data).data)['weight']).to eql(2)
       end
     end
 

--- a/spec/lib/nerve/reporter_spec.rb
+++ b/spec/lib/nerve/reporter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'nerve/reporter/zookeeper'
 
 describe Nerve::Reporter do
   let(:subject) { {
@@ -30,13 +31,42 @@ end
 
 describe Nerve::Reporter::Test do
   let(:subject) {Nerve::Reporter::Test.new({}) }
-  it 'has parse data method that passes strings' do
-    expect(subject.send(:parse_data, 'foobar')).to eql('foobar')
+  context 'parse_data method' do
+    it 'has parse data method that passes strings' do
+      expect(subject.send(:parse_data, 'foobar')).to eql('foobar')
+    end
+    it 'jsonifies anything that is not a string' do
+      thing_to_parse = double()
+      expect(thing_to_parse).to receive(:to_json).and_return('{"some":"json"}')
+      expect(subject.send(:parse_data, thing_to_parse)).to eql('{"some":"json"}')
+    end
   end
-  it 'jsonifies anything that is not a string' do
-    thing_to_parse = double()
-    expect(thing_to_parse).to receive(:to_json).and_return('{"some":"json"}')
-    expect(subject.send(:parse_data, thing_to_parse)).to eql('{"some":"json"}')
+
+  context 'get_service_data method' do
+    it 'throws on missing arguments' do
+      expect { subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666}) }.to raise_error(ArgumentError)
+      expect { subject.get_service_data({'host' => '127.0.0.1', 'instance_id' => 'foobar'}) }.to raise_error(ArgumentError)
+      expect { subject.get_service_data({'port' => 6666, 'instance_id' => 'foobar'}) }.to raise_error(ArgumentError)
+      expect { subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar'}) }.not_to raise_error
+    end
+    it 'takes weight if present and +ve integer' do
+      expect(subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar', 'weight' => 3})['weight']).to eql(3)
+    end
+    it 'takes weight if present and 0' do
+      expect(subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar', 'weight' => 0})['weight']).to eql(0)
+    end
+    it 'skips weight if not present' do
+      expect(subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar'})['weight']).to eql(nil)
+    end
+    it 'skips weight if non integer' do
+      expect(subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar', 'weight' => 'hello'})['weight']).to eql(nil)
+    end
+    it 'skips weight if a negative integer' do
+      expect(subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar', 'weight' => -1})['weight']).to eql(nil)
+    end
+    it 'works if the weight is a string' do
+      expect(subject.get_service_data({'host' => '127.0.0.1', 'port' => 6666, 'instance_id' => 'foobar', 'weight' => '3'})['weight']).to eql(3)
+    end
   end
 end
 


### PR DESCRIPTION
For the extlbs => webs in physical datacenters where we have several generations of hardware, we want / need to be able to distribute a per host weighting value which can then get reused in the haproxy configs to set backend weights.
