### PR TITLE
Fix bug in session disconnects with pooling

### DIFF
--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -70,7 +70,7 @@ class Nerve::Reporter
     end
 
     def ping?
-      return @zk.ping?
+      return @zk.connected? && @zk.exists?(@full_key || '/')
     end
 
     private

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -87,7 +87,11 @@ module Nerve
     end
 
     def check_and_report
-      @reporter.ping?
+      if !@reporter.ping?
+        # If the reporter can't ping, then we do not know the status
+        # and must force a new report.
+        @was_up = nil
+      end
 
       # what is the status of the service?
       is_up = check?


### PR DESCRIPTION
If we get a session disconnect we need to ensure that nerve recreates
the ephemeral nodes when it reconnects.
