### PR TITLE
Pull upstream to fix ruby 1.9.3 compat issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
+  - 1.9.3
   - 2.0.0-p648
   - 2.1.10
   - 2.2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nerve (0.9.1)
+    nerve (0.9.3)
       bunny (= 1.1.0)
       dogstatsd-ruby (~> 3.3.0)
       etcd (~> 0.2.3)

--- a/lib/nerve/rate_limiter.rb
+++ b/lib/nerve/rate_limiter.rb
@@ -6,7 +6,10 @@ module Nerve
   # Note: a single instance of RateLimiter is *not* thread-safe.
   # See: https://en.wikipedia.org/wiki/Token_bucket
   class RateLimiter
-    def initialize(average_rate: Float::INFINITY, max_burst: Float::INFINITY)
+    def initialize(options = {})
+      average_rate = options[:average_rate] || Float::Infinity
+      max_burst = options[:max_burst] || Float::Infinity
+
       raise ArgumentError, "average_rate should be numeric" unless average_rate.is_a? Numeric
       raise ArgumentError, "average_rate should be positive or zero" unless average_rate >= 0
       raise ArgumentError, "max_burst should be numeric" unless max_burst.is_a? Numeric

--- a/lib/nerve/version.rb
+++ b/lib/nerve/version.rb
@@ -1,3 +1,3 @@
 module Nerve
-  VERSION = "0.9.1"
+  VERSION = "0.9.3"
 end


### PR DESCRIPTION
Right now we'll see with error when we try to run Yelp/nerve master on Ruby 1.9.3:

```
+ exec setuidgid nobody nerve --config /etc/nerve/nerve.conf.json
bundler: failed to load command: /opt/nerve/bin/nerve (/opt/nerve/bin/nerve)
SyntaxError: /opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve/rate_limiter.rb:9: syntax error, unexpected tLABEL, expecting ')'
...   def initialize(average_rate: Float::INFINITY, max_burst: ...
...                               ^
/opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve/rate_limiter.rb:9: dynamic constant assignment
...(average_rate: Float::INFINITY, max_burst: Float::INFINITY)
...                               ^
/opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve/rate_limiter.rb:9: syntax error, unexpected tLABEL, expecting '='
...te: Float::INFINITY, max_burst: Float::INFINITY)
...                               ^
/opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve/rate_limiter.rb:9: syntax error, unexpected ')', expecting keyword_end
/opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve/rate_limiter.rb:46: syntax error, unexpected keyword_end, expecting $end
  /opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve/service_watcher.rb:6:in `require'
  /opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve/service_watcher.rb:6:in `<top (required)>'
  /opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve.rb:12:in `require'
  /opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/lib/nerve.rb:12:in `<top (required)>'
  /opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/bin/nerve:6:in `require'
  /opt/nerve/vendor/bundle/ruby/1.9.1/bundler/gems/nerve-17c3a9d76c50/bin/nerve:6:in `<top (required)>'
  /opt/nerve/bin/nerve:17:in `load'
  /opt/nerve/bin/nerve:17:in `<top (required)>'
```

There's a fix for this upstream, let's use it.