### PR TITLE
add prometheus metrics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,9 @@ PATH
       dogstatsd-ruby (~> 5.0)
       etcd (~> 0.3)
       json
+      prometheus-client (~> 4.0)
       redis (~> 5.0)
+      webrick
       zk (~> 1.10)
 
 GEM
@@ -70,6 +72,8 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.7.0)
+    prometheus-client (4.2.5)
+      base64
     pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -140,6 +144,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
+    webrick (1.9.2)
     zk (1.10.0)
       zookeeper (~> 1.5.0)
     zookeeper (1.5.5)
@@ -204,6 +209,7 @@ CHECKSUMS
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.0) sha256=ce3587fa5cc55a88c4ba5b2b37621b3329aadf5728f9eafa36bbd121462aabd6
   prism (1.7.0) sha256=10062f734bf7985c8424c44fac382ac04a58124ea3d220ec3ba9fe4f2da65103
+  prometheus-client (4.2.5) sha256=807bebc3e92ccd9f4d814d90be15e85338f3708d227badf80924ef3f6e7d5225
   pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
@@ -232,6 +238,7 @@ CHECKSUMS
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   zk (1.10.0) sha256=e7151a665d6f5974a8d569d1b7a28c7c0110e4679b8f834fa54429dd4cbb569f
   zookeeper (1.5.5) sha256=6fcf3b2ac40158968bead2425abf9ca225db673014aba0f4a4a3b057d73d88c1
 

--- a/example/nerve.conf.json
+++ b/example/nerve.conf.json
@@ -6,6 +6,13 @@
     "host": "localhost",
     "port": 8125
   },
+  "prometheus": {
+    "enabled": true,
+    "port": 9292,
+    "bind": "0.0.0.0",
+    "histogram_buckets_zk": [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+    "histogram_buckets_main_loop": [0.001, 0.01, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0]
+  },
   "services": {
     "your_http_service": {
       "host": "1.2.3.4",

--- a/lib/nerve/prometheus_metrics.rb
+++ b/lib/nerve/prometheus_metrics.rb
@@ -66,6 +66,65 @@ module Nerve
       private
 
       def register_metrics(zk_buckets: HISTOGRAM_BUCKETS_ZK, main_loop_buckets: HISTOGRAM_BUCKETS_MAIN_LOOP)
+        # Gauges
+        @@prom_metrics[:watchers_desired] = @@prom_registry.gauge(
+          :nerve_watchers_desired,
+          docstring: "Number of service watchers desired from config"
+        )
+        @@prom_metrics[:watchers_running] = @@prom_registry.gauge(
+          :nerve_watchers_running,
+          docstring: "Number of service watchers currently running"
+        )
+        @@prom_metrics[:watchers_up] = @@prom_registry.gauge(
+          :nerve_watchers_up,
+          docstring: "Number of service watchers currently reporting up"
+        )
+        @@prom_metrics[:watchers_down] = @@prom_registry.gauge(
+          :nerve_watchers_down,
+          docstring: "Number of service watchers currently reporting down"
+        )
+        @@prom_metrics[:repeated_report_failures_max] = @@prom_registry.gauge(
+          :nerve_repeated_report_failures_max,
+          docstring: "Worst-case repeated report failure count across all watchers"
+        )
+
+        # Counters
+        @@prom_metrics[:report_results_total] = @@prom_registry.counter(
+          :nerve_report_results_total,
+          docstring: "Total report up/down attempts and results",
+          labels: [:action, :result]
+        )
+        @@prom_metrics[:reporter_ping_results_total] = @@prom_registry.counter(
+          :nerve_reporter_ping_results_total,
+          docstring: "Total reporter ping results",
+          labels: [:result]
+        )
+        @@prom_metrics[:watcher_stops_total] = @@prom_registry.counter(
+          :nerve_watcher_stops_total,
+          docstring: "Total watcher stop events",
+          labels: [:reason]
+        )
+        @@prom_metrics[:watcher_launches_total] = @@prom_registry.counter(
+          :nerve_watcher_launches_total,
+          docstring: "Total watcher launch events",
+          labels: [:reason]
+        )
+        @@prom_metrics[:watcher_throttled_total] = @@prom_registry.counter(
+          :nerve_watcher_throttled_total,
+          docstring: "Total watcher throttle events"
+        )
+        @@prom_metrics[:config_reloads_total] = @@prom_registry.counter(
+          :nerve_config_reloads_total,
+          docstring: "Total configuration reloads"
+        )
+
+        # Histograms
+        @@prom_metrics[:main_loop_duration_seconds] = @@prom_registry.histogram(
+          :nerve_main_loop_duration_seconds,
+          docstring: "Duration of main loop iterations in seconds",
+          buckets: main_loop_buckets
+        )
+
         # Info
         @@prom_metrics[:build_info] = @@prom_registry.gauge(
           :nerve_build_info,

--- a/lib/nerve/prometheus_metrics.rb
+++ b/lib/nerve/prometheus_metrics.rb
@@ -1,0 +1,117 @@
+require "webrick"
+require "prometheus/client"
+require "prometheus/client/formats/text"
+require "nerve/log"
+require "nerve/version"
+
+module Nerve
+  module PrometheusMetrics
+    HISTOGRAM_BUCKETS_ZK = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0].freeze
+    HISTOGRAM_BUCKETS_MAIN_LOOP = [0.001, 0.01, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0].freeze
+
+    class << self
+      include Logging
+
+      @@prom_enabled = false
+      @@prom_registry = nil
+      @@prom_metrics = {}
+      @@prom_server = nil
+
+      def enabled?
+        @@prom_enabled
+      end
+
+      def registry
+        @@prom_registry
+      end
+
+      def metrics
+        @@prom_metrics
+      end
+
+      def configure(opts)
+        return unless opts && opts["enabled"]
+
+        @@prom_enabled = true
+        @@prom_registry = Prometheus::Client::Registry.new
+
+        zk_buckets = opts["histogram_buckets_zk"] || HISTOGRAM_BUCKETS_ZK
+        main_loop_buckets = opts["histogram_buckets_main_loop"] || HISTOGRAM_BUCKETS_MAIN_LOOP
+        register_metrics(zk_buckets: zk_buckets, main_loop_buckets: main_loop_buckets)
+
+        port = opts["port"] || 9292
+        bind = opts["bind"] || "0.0.0.0"
+        start_server(bind, port)
+
+        log.info "nerve: prometheus metrics enabled on #{bind}:#{port}/metrics"
+      end
+
+      def stop_server
+        if @@prom_server
+          log.info "nerve: stopping prometheus metrics server"
+          @@prom_server.shutdown
+          @@prom_server = nil
+        end
+      end
+
+      def disable!
+        return unless @@prom_enabled
+        stop_server
+        @@prom_enabled = false
+        @@prom_registry = nil
+        @@prom_metrics = {}
+        @@prom_server = nil
+      end
+
+      private
+
+      def register_metrics(zk_buckets: HISTOGRAM_BUCKETS_ZK, main_loop_buckets: HISTOGRAM_BUCKETS_MAIN_LOOP)
+        # Info
+        @@prom_metrics[:build_info] = @@prom_registry.gauge(
+          :nerve_build_info,
+          docstring: "Nerve build information",
+          labels: [:version]
+        )
+        @@prom_metrics[:build_info].set(1, labels: {version: VERSION})
+      end
+
+      def start_server(bind, port)
+        registry = @@prom_registry
+        @@prom_server = WEBrick::HTTPServer.new(
+          Port: port,
+          BindAddress: bind,
+          Logger: WEBrick::Log.new(File::NULL),
+          AccessLog: []
+        )
+
+        @@prom_server.mount_proc "/metrics" do |_req, res|
+          res["Content-Type"] = Prometheus::Client::Formats::Text::CONTENT_TYPE
+          res.body = Prometheus::Client::Formats::Text.marshal(registry)
+        end
+
+        Thread.new { @@prom_server.start }
+      end
+    end
+
+    def prom_inc(metric_name, labels: {}, by: 1)
+      return unless PrometheusMetrics.enabled?
+      metric = PrometheusMetrics.metrics[metric_name]
+      return unless metric
+      metric.increment(labels: labels, by: by)
+    end
+
+    def prom_set(metric_name, value, labels: {})
+      return unless PrometheusMetrics.enabled?
+      metric = PrometheusMetrics.metrics[metric_name]
+      return unless metric
+      metric.set(value, labels: labels)
+    end
+
+    def prom_observe(metric_name, value, labels: {})
+      return unless PrometheusMetrics.enabled?
+      metric = PrometheusMetrics.metrics[metric_name]
+      return unless metric
+      metric.observe(value, labels: labels)
+    end
+  end
+end

--- a/lib/nerve/reporter.rb
+++ b/lib/nerve/reporter.rb
@@ -1,5 +1,7 @@
 require "nerve/utils"
 require "nerve/log"
+require "nerve/statsd"
+require "nerve/prometheus_metrics"
 require "nerve/reporter/base"
 
 module Nerve

--- a/lib/nerve/reporter/base.rb
+++ b/lib/nerve/reporter/base.rb
@@ -3,6 +3,7 @@ class Nerve::Reporter
     include Nerve::Utils
     include Nerve::Logging
     include Nerve::StatsD
+    include Nerve::PrometheusMetrics
 
     def initialize(opts)
     end

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -10,6 +10,7 @@ module Nerve
     include Utils
     include Logging
     include StatsD
+    include PrometheusMetrics
 
     attr_reader :was_up
 

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "redis", "~> 5.0"
   gem.add_runtime_dependency "etcd", "~> 0.3"
   gem.add_runtime_dependency "dogstatsd-ruby", "~> 5.0"
+  gem.add_runtime_dependency "prometheus-client", "~> 4.0"
+  gem.add_runtime_dependency "webrick"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.13"

--- a/spec/lib/nerve/prometheus_metrics_spec.rb
+++ b/spec/lib/nerve/prometheus_metrics_spec.rb
@@ -1,0 +1,116 @@
+require "spec_helper"
+require "nerve/prometheus_metrics"
+
+describe Nerve::PrometheusMetrics do
+  let(:test_class) do
+    Class.new do
+      include Nerve::PrometheusMetrics
+    end
+  end
+  let(:instance) { test_class.new }
+
+  after(:each) do
+    Nerve::PrometheusMetrics.stop_server
+    Nerve::PrometheusMetrics.class_variable_set(:@@prom_enabled, false)
+    Nerve::PrometheusMetrics.class_variable_set(:@@prom_registry, nil)
+    Nerve::PrometheusMetrics.class_variable_set(:@@prom_metrics, {})
+    Nerve::PrometheusMetrics.class_variable_set(:@@prom_server, nil)
+  end
+
+  def configure_without_server(opts = {})
+    allow(Nerve::PrometheusMetrics).to receive(:start_server)
+    Nerve::PrometheusMetrics.configure({"enabled" => true}.merge(opts))
+  end
+
+  describe ".configure" do
+    it "does nothing when opts is nil" do
+      Nerve::PrometheusMetrics.configure(nil)
+      expect(Nerve::PrometheusMetrics.enabled?).to be false
+    end
+
+    it "does nothing when enabled is false" do
+      Nerve::PrometheusMetrics.configure({"enabled" => false})
+      expect(Nerve::PrometheusMetrics.enabled?).to be false
+    end
+
+    it "does nothing when opts is empty hash" do
+      Nerve::PrometheusMetrics.configure({})
+      expect(Nerve::PrometheusMetrics.enabled?).to be false
+    end
+
+    it "enables metrics when enabled is true" do
+      configure_without_server
+      expect(Nerve::PrometheusMetrics.enabled?).to be true
+    end
+
+    it "creates a registry" do
+      configure_without_server
+      expect(Nerve::PrometheusMetrics.registry).to be_a(Prometheus::Client::Registry)
+    end
+
+    it "sets build_info with version" do
+      configure_without_server
+      metric = Nerve::PrometheusMetrics.metrics[:build_info]
+      expect(metric.get(labels: {version: Nerve::VERSION})).to eq(1)
+    end
+  end
+
+  describe "instance helpers when disabled" do
+    it "prom_inc is a no-op" do
+      expect { instance.prom_inc(:config_reloads_total) }.not_to raise_error
+    end
+
+    it "prom_set is a no-op" do
+      expect { instance.prom_set(:watchers_desired, 5) }.not_to raise_error
+    end
+
+    it "prom_observe is a no-op" do
+      expect { instance.prom_observe(:main_loop_duration_seconds, 1.0) }.not_to raise_error
+    end
+  end
+
+  describe "instance helpers when enabled" do
+    before(:each) do
+      configure_without_server
+    end
+
+    it "prom_inc ignores unknown metrics" do
+      expect { instance.prom_inc(:nonexistent_metric) }.not_to raise_error
+    end
+
+    it "prom_set ignores unknown metrics" do
+      expect { instance.prom_set(:nonexistent_metric, 1) }.not_to raise_error
+    end
+
+    it "prom_observe ignores unknown metrics" do
+      expect { instance.prom_observe(:nonexistent_metric, 1.0) }.not_to raise_error
+    end
+  end
+
+  describe "HTTP server" do
+    it "serves /metrics endpoint" do
+      Nerve::PrometheusMetrics.configure({"enabled" => true, "port" => 19297})
+      sleep 0.2
+
+      require "net/http"
+      response = Net::HTTP.get_response("127.0.0.1", "/metrics", 19297)
+      expect(response.code).to eq("200")
+      expect(response["content-type"]).to include("text/plain")
+      expect(response.body).to include("nerve_build_info")
+    end
+  end
+
+  describe ".stop_server" do
+    it "stops the server cleanly" do
+      mock_server = double("WEBrick::HTTPServer")
+      expect(mock_server).to receive(:shutdown)
+      Nerve::PrometheusMetrics.class_variable_set(:@@prom_server, mock_server)
+      expect { Nerve::PrometheusMetrics.stop_server }.not_to raise_error
+      expect(Nerve::PrometheusMetrics.class_variable_get(:@@prom_server)).to be_nil
+    end
+
+    it "is safe to call when no server is running" do
+      expect { Nerve::PrometheusMetrics.stop_server }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/nerve_spec.rb
+++ b/spec/lib/nerve_spec.rb
@@ -11,6 +11,7 @@ def make_mock_service_watcher
   allow(mock_service_watcher).to receive(:stop)
   allow(mock_service_watcher).to receive(:alive?).and_return(true)
   allow(mock_service_watcher).to receive(:was_up).and_return(true)
+  allow(mock_service_watcher).to receive(:repeated_report_failures).and_return(0)
   mock_service_watcher
 end
 


### PR DESCRIPTION
I've tried to split into smaller commits to make this easier to review.

adds a /metrics prometheus endpoint to nerve. this means running a webserver in nerve, in a background thread.

I've added an initial set of metrics that should give us some insights on nerve itself, and its interactions with zookeeper. also added the build_info metric so we can compare performance on new releases (we'll be iterating on this loads now right?)

the prom server is off by default - enabled by a feature toggle