### PR TITLE
fix: ensure instance_id overrides overlay

### DIFF
--- a/lib/nerve/configuration_manager.rb
+++ b/lib/nerve/configuration_manager.rb
@@ -68,13 +68,13 @@ module Nerve
         cfiles.each { |x| config["services"][File.basename(x[/(.*)\.(yaml|json)$/, 1])] = parse_config_file(x) }
       end
 
-      if options[:instance_id] && !options[:instance_id].empty?
-        config["instance_id"] = options[:instance_id]
-      end
-
       if options[:config_overlay]
         overlay = parse_overlay_file(options[:config_overlay])
         config = deep_merge(config, overlay) if overlay
+      end
+
+      if options[:instance_id] && !options[:instance_id].empty?
+        config["instance_id"] = options[:instance_id]
       end
 
       config

--- a/spec/configuration_manager_spec.rb
+++ b/spec/configuration_manager_spec.rb
@@ -96,7 +96,7 @@ describe Nerve::ConfigurationManager do
       })
     end
 
-    it "instance_id flag still wins over overlay when set" do
+    it "instance_id flag wins over overlay when set" do
       overlay_path = File.join(tmpdir, "overlay.json")
       File.write(overlay_path, JSON.generate({
         "instance_id" => "overlay_instance"
@@ -113,8 +113,8 @@ describe Nerve::ConfigurationManager do
       config_manager.parse_options!
       config_manager.reload!
 
-      # Overlay is applied after instance_id flag, so overlay wins
-      expect(config_manager.config["instance_id"]).to eq("overlay_instance")
+      # Overlay is applied before instance_id flag, so flag wins
+      expect(config_manager.config["instance_id"]).to eq(nerve_instance_id)
     end
 
     it "loads config without error when overlay file is missing" do


### PR DESCRIPTION
make the --instance_id cli flag take precedence over the overlay config. this was a regression i introduced with the overlay config